### PR TITLE
Update to 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '0.12.+'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.6
 
 # Mod Properties
-	mod_version = 1.0.2-Fabric-1.19
+	mod_version = 1.0.2
 	maven_group = us.potatoboy
 	archives_base_name = timeoutout
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.18
-	yarn_mappings=1.18+build.1
-	loader_version=0.12.6
+	minecraft_version=1.19
+	yarn_mappings=1.19+build.1
+	loader_version=0.14.6
 
 # Mod Properties
-	mod_version = 1.0.1
+	mod_version = 1.0.2-Fabric-1.19
 	maven_group = us.potatoboy
 	archives_base_name = timeoutout
 
 # Dependencies
-	fabric_version=0.43.1+1.18
+	fabric_version=0.55.1+1.19

--- a/src/main/java/us/potatoboy/timeoutout/mixin/ServerLoginNetworkHandlerMixin.java
+++ b/src/main/java/us/potatoboy/timeoutout/mixin/ServerLoginNetworkHandlerMixin.java
@@ -2,7 +2,6 @@ package us.potatoboy.timeoutout.mixin;
 
 import net.minecraft.server.network.ServerLoginNetworkHandler;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -20,7 +19,7 @@ public final class ServerLoginNetworkHandlerMixin {
     private void tick(CallbackInfo info) {
         if (loginTicks >= TimeOutOut.getConfig().loginTimeoutTicks) {
             ((ServerLoginNetworkHandler) (Object) this).disconnect(
-                    new TranslatableText("multiplayer.disconnect.slow_login")
+                    Text.translatable("multiplayer.disconnect.slow_login")
             );
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": ">=1.18",
+    "minecraft": ">=1.19",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
- `new TranslatableText` -> `Text.translatable`
- bump versions

Might want to create a 1.18 branch off the current `master` before merging this, so that it's convenient to make further changes to both versions.